### PR TITLE
Fix hardcoded DEFAULT_PROXY_URL and centralize constant

### DIFF
--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -18,6 +18,7 @@ import {
 	type RepositoryConfig,
 	SharedApplicationServer,
 } from "cyrus-edge-worker";
+import { DEFAULT_PROXY_URL } from "cyrus-core";
 import dotenv from "dotenv";
 import open from "open";
 
@@ -26,8 +27,7 @@ const args = process.argv.slice(2);
 const envFileArg = args.find((arg) => arg.startsWith("--env-file="));
 const cyrusHomeArg = args.find((arg) => arg.startsWith("--cyrus-home="));
 
-// Constants
-const DEFAULT_PROXY_URL = "https://cyrus-proxy.ceedar.workers.dev";
+// Constants are imported from cyrus-core
 
 // Determine the Cyrus home directory once at startup
 let CYRUS_HOME: string;
@@ -1612,7 +1612,8 @@ async function refreshTokenCommand() {
 			? parseInt(process.env.CYRUS_SERVER_PORT, 10)
 			: 3456;
 		const callbackUrl = `http://localhost:${serverPort}/callback`;
-		const oauthUrl = `${DEFAULT_PROXY_URL}/oauth/authorize?callback=${encodeURIComponent(
+		const proxyUrl = process.env.PROXY_URL || DEFAULT_PROXY_URL;
+		const oauthUrl = `${proxyUrl}/oauth/authorize?callback=${encodeURIComponent(
 			callbackUrl,
 		)}`;
 
@@ -1739,8 +1740,7 @@ async function addRepositoryCommand() {
 			console.log("🔐 No Linear credentials found. Starting OAuth flow...");
 
 			// Start OAuth flow using the default proxy URL
-			const proxyUrl =
-				process.env.PROXY_URL || "https://cyrus-proxy.ceedar.workers.dev";
+			const proxyUrl = process.env.PROXY_URL || DEFAULT_PROXY_URL;
 			linearCredentials = await app.startOAuthFlow(proxyUrl);
 
 			if (!linearCredentials) {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared constants used across Cyrus packages
+ */
+
+/**
+ * Default proxy URL for Cyrus hosted services
+ */
+export const DEFAULT_PROXY_URL = "https://cyrus-proxy.ceedar.workers.dev";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,3 +47,6 @@ export {
 	isIssueNewCommentWebhook,
 	isIssueUnassignedWebhook,
 } from "./webhook-types.js";
+
+// Constants
+export { DEFAULT_PROXY_URL } from "./constants.js";

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -6,6 +6,7 @@ import {
 } from "node:http";
 import { URL } from "node:url";
 import { forward } from "@ngrok/ngrok";
+import { DEFAULT_PROXY_URL } from "cyrus-core";
 
 /**
  * OAuth callback handler interface
@@ -73,7 +74,7 @@ export class SharedApplicationServer {
 		this.proxyUrl =
 			proxyUrl ||
 			process.env.PROXY_URL ||
-			"https://cyrus-proxy.ceedar.workers.dev";
+			DEFAULT_PROXY_URL;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fix hardcoded DEFAULT_PROXY_URL references that ignored PROXY_URL environment variable
- Centralize DEFAULT_PROXY_URL constant in cyrus-core package to follow DRY principle
- Ensure all commands respect custom proxy URLs consistently

## Changes Made
- **Fixed refreshTokenCommand**: Now respects PROXY_URL environment variable instead of hardcoded default
- **Fixed addRepositoryCommand**: Updated to use DEFAULT_PROXY_URL constant instead of hardcoded string
- **Fixed SharedApplicationServer**: Updated to use DEFAULT_PROXY_URL constant instead of hardcoded string
- **Created shared constants**: Added `/packages/core/src/constants.ts` as single source of truth
- **Updated imports**: All packages now import DEFAULT_PROXY_URL from cyrus-core

## Test Plan
- [x] All package tests pass (81 tests)
- [x] CLI tests pass (27 tests) 
- [x] TypeScript compilation succeeds across all packages
- [x] Build process completes successfully
- [x] Environment variable PROXY_URL is now respected by all commands
- [x] No hardcoded proxy URLs remain except in shared constants file

## Impact
Users with custom Cloudflare Workers domains (like `cyrus-proxy.gudzenkov.workers.dev`) will now have all commands consistently respect their PROXY_URL environment variable, including the previously broken `cyrus refresh-token` command.

🤖 Generated with [Claude Code](https://claude.ai/code)